### PR TITLE
Fixed #401 and #431 :  address issues with addon list and quantity validation

### DIFF
--- a/enatega-multivendor-admin/src/components/Addon/Addon.jsx
+++ b/enatega-multivendor-admin/src/components/Addon/Addon.jsx
@@ -76,19 +76,7 @@ function Addon(props) {
             quantityMaximumError: false
           }
         ]
-      : [
-          {
-            title: '',
-            description: '',
-            quantityMinimum: 0,
-            quantityMaximum: 1,
-            options: [],
-            titleError: false,
-            optionsError: false,
-            quantityMinimumError: false,
-            quantityMaximumError: false
-          }
-        ]
+      : []
   )
   const [modal, modalSetter] = useState(false)
   const [addonIndex, addonIndexSetter] = useState(0)
@@ -124,7 +112,8 @@ function Addon(props) {
       )
       addons[index].quantityMinimumError =
         addons[index].quantityMinimumError ||
-        addons[index].quantityMinimum > addons[index].quantityMaximum
+        addons[index].quantityMinimum > addons[index].quantityMaximum ||
+        addons[index].quantityMinimum === 0 // Added check for zero value
       addons[index].quantityMinimumError =
         addons[index].options.length < addons[index][state]
     }
@@ -135,7 +124,8 @@ function Addon(props) {
       )
       addons[index].quantityMaximumError =
         addons[index].quantityMaximumError ||
-        addons[index].quantityMaximum < addons[index].quantityMinimum
+        addons[index].quantityMaximum < addons[index].quantityMinimum ||
+        addons[index].quantityMaximum === 0 // Added check for zero value
     }
     if (state === 'options') {
       addons[index].optionsError = addons[index].options.length === 0


### PR DESCRIPTION
What this PR does ?

**Fixed #401 and #431** 

- Initialize the addon state as an empty array when there is no initial addon data
- Update the validation logic for quantityMinimum and quantityMaximum to mark values of zero as errors

The addon list will now be empty initially when there is no pre-existing addon data. 
Additionally, the quantityMinimum and quantityMaximum fields will not accept a value of zero and will only allow positive integers greater than zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error checking and initialization in the addon management component, ensuring better handling of quantity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->