### PR TITLE
Fix: Hide 'Enter Amount' text when user inputs amount

### DIFF
--- a/enatega-multivendor-rider/src/screens/Withdraw/Withdraw.js
+++ b/enatega-multivendor-rider/src/screens/Withdraw/Withdraw.js
@@ -80,7 +80,7 @@ const Withdraw = () => {
                 textColor={
                   error ? colors.textErrorColor : colors.fontSecondColor
                 }>
-                {error || t('enteramount')}
+                {amount ? '' : (error || t('enteramount'))}
               </TextDefault>
             </View>
             <View style={styles.btnView}>


### PR DESCRIPTION
Hides the 'Enter Amount' text once the user inputs a value to improve the UI experience.