### PR TITLE
Allow single-letter first name during sign-up (#885)

### DIFF
--- a/enatega-multivendor-app/src/utils/regex.js
+++ b/enatega-multivendor-app/src/utils/regex.js
@@ -1,6 +1,6 @@
 export const emailRegex = /^\w+([\\.-]?\w+)*@\w+([\\.-]?\w+)*(\.\w{2,3})+$/
 export const passRegex = /^(?=.*\d)(?=.*[a-zA-Z]).{8,}$/
-export const nameRegex = /^[\p{L}][\p{L}\s'-]+$/u
+export const nameRegex = /^[\p{L}][\p{L}\s'-]*$/u
 export const phoneRegex = /^\d{7,15}$/
 
 


### PR DESCRIPTION
Original nameRegex (/^[\p{L}][\p{L}\s'-]+$/u):
Does not allow single-character names because the + quantifier requires at least one additional character.
Updated nameRegex (/^[\p{L}][\p{L}\s'-]*$/u):
Allows single-character names because the * quantifier makes the additional characters optional.

Fixes #885