### PR TITLE
Enatega Restaurant Application: #844 Add active state green highlight to Profile button when menu/drawer is opened

### DIFF
--- a/enatega-multivendor-restaurant/src/navigation/mainStack.js
+++ b/enatega-multivendor-restaurant/src/navigation/mainStack.js
@@ -139,9 +139,8 @@ function TabNavigator({route}) {
         component={SideBar}
         listeners={({ navigation }) => ({
           tabPress: e => {
-            e.preventDefault(); // Prevents tab switch to open the drawer
+            e.preventDefault(); // Prevent tab switch to open the drawer
             // Toggle the drawer on "Profile" tab press
-            // open the tab without actually opening it
             toggleDrawer();
             
           },
@@ -151,7 +150,6 @@ function TabNavigator({route}) {
       <Tabs.Screen name={t('titleHome')} component={StackNavigator} />
       {/* {Platform.OS === 'ios' ? null :  */}
       <Tabs.Screen name='Language' options={{
-          tabBarLabel: t('language')
         }} component={SelectLanguage} />
         {/* } */}
     </Tabs.Navigator>

--- a/enatega-multivendor-restaurant/src/navigation/mainStack.js
+++ b/enatega-multivendor-restaurant/src/navigation/mainStack.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useCallback } from 'react'
 import * as Notifications from 'expo-notifications'
 import { Restaurant, SoundContextProvider } from '../ui/context'
 import { OrderDetailScreen } from '../screens/OrderDetail'
@@ -123,11 +123,6 @@ function TabNavigator({route}) {
     }
   };
   
-  // Add event listeners to track drawer state changes for debugging purposes
-  useEffect(() => {
-    console.log("DRAWER STATE AFTER UPDATE: ", drawerStatus);
-  });  
-
   return (
     <Tabs.Navigator
       initialRouteName={t('titleHome')}
@@ -139,7 +134,8 @@ function TabNavigator({route}) {
         component={SideBar}
         listeners={({ navigation }) => ({
           tabPress: e => {
-            e.preventDefault(); // Prevent tab switch to open the drawer
+            e.preventDefault(); // This prevents tab functionalities
+
             // Toggle the drawer on "Profile" tab press
             toggleDrawer();
             

--- a/enatega-multivendor-restaurant/src/navigation/mainStack.js
+++ b/enatega-multivendor-restaurant/src/navigation/mainStack.js
@@ -139,8 +139,9 @@ function TabNavigator({route}) {
         component={SideBar}
         listeners={({ navigation }) => ({
           tabPress: e => {
-            e.preventDefault(); // Prevent tab switch to open the drawer
+            e.preventDefault(); // Prevents tab switch to open the drawer
             // Toggle the drawer on "Profile" tab press
+            // open the tab without actually opening it
             toggleDrawer();
             
           },

--- a/enatega-multivendor-restaurant/src/navigation/screenOptions.js
+++ b/enatega-multivendor-restaurant/src/navigation/screenOptions.js
@@ -20,8 +20,13 @@ const tabIcon = (route, drawerStatus) => ({
   },
   tabBarLabel: ({ focused, color }) => {
     // Dynamically set the label color based on drawerStatus and route name
-    const labelColor = (drawerStatus === 'open' && (route.name === "Profile"))
+    const {t} = useTranslation()
+    console.log('Route Name:', route.name); // Check the actual route name
+  console.log('Language Translation:', t('language'));
+    const labelColor = (drawerStatus === 'open' && (route.name === 'Profile'))
       ? colors.green
+      : (drawerStatus === 'open' && (route.name === 'Home' || route.name === 'Language'))
+      ? colors.white 
       : focused
       ? colors.green
       : colors.white;

--- a/enatega-multivendor-restaurant/src/navigation/screenOptions.js
+++ b/enatega-multivendor-restaurant/src/navigation/screenOptions.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dimensions, View, Platform } from 'react-native'
+import { Dimensions, View, Platform, Text } from 'react-native'
 import { textStyles, scale, colors } from '../utilities'
 import { Icon } from 'react-native-elements'
 import {useTranslation} from 'react-i18next'
@@ -18,12 +18,28 @@ const tabIcon = (route, drawerStatus) => ({
     justifyContent: 'center',
     alignItems: 'center'
   },
+  tabBarLabel: ({ focused, color }) => {
+    // Dynamically set the label color based on drawerStatus and route name
+    const labelColor = (drawerStatus === 'open' && (route.name === "Profile"))
+      ? colors.green
+      : focused
+      ? colors.green
+      : colors.white;
+
+    return (
+      <Text style={{ color: labelColor, fontSize: 12, paddingBottom: Platform.OS === 'android' ? 8 : 8,
+        ...textStyles.Bold,
+        ...textStyles.Center,
+        ...textStyles.Small,}}>
+        {route.name}
+      </Text>
+    );
+  },
   tabBarLabelStyle: {
     paddingBottom: Platform.OS === 'android' ? 8 : 8,
     ...textStyles.Bold,
     ...textStyles.Center,
-    ...textStyles.Small,
-    color: (drawerStatus === 'open' && route.name === "Profile") ? colors.green : colors.white
+    ...textStyles.Small
   },
   tabBarStyle: {
     position: 'absolute',

--- a/enatega-multivendor-restaurant/src/navigation/screenOptions.js
+++ b/enatega-multivendor-restaurant/src/navigation/screenOptions.js
@@ -20,9 +20,7 @@ const tabIcon = (route, drawerStatus) => ({
   },
   tabBarLabel: ({ focused, color }) => {
     // Dynamically set the label color based on drawerStatus and route name
-    const {t} = useTranslation()
-    console.log('Route Name:', route.name); // Check the actual route name
-  console.log('Language Translation:', t('language'));
+    // As Profile Menu is not a Tab but a Drawer
     const labelColor = (drawerStatus === 'open' && (route.name === 'Profile'))
       ? colors.green
       : (drawerStatus === 'open' && (route.name === 'Home' || route.name === 'Language'))
@@ -56,6 +54,7 @@ const tabIcon = (route, drawerStatus) => ({
   },
   tabBarIcon: ({ color, size, focused}) => {
     let iconName
+    // Dynamically set the icon color based on drawerStatus and route name
 
     const {t} = useTranslation()
     if (route.name === t('titleHome')) {

--- a/enatega-multivendor-restaurant/src/navigation/screenOptions.js
+++ b/enatega-multivendor-restaurant/src/navigation/screenOptions.js
@@ -3,12 +3,13 @@ import { Dimensions, View, Platform } from 'react-native'
 import { textStyles, scale, colors } from '../utilities'
 import { Icon } from 'react-native-elements'
 import {useTranslation} from 'react-i18next'
+import { color } from 'react-native-elements/dist/helpers'
 
 const { height } = Dimensions.get('window')
 const screenOptions = props => ({
   headerShown: false
 })
-const tabIcon = route => ({
+const tabIcon = (route, drawerStatus) => ({
   headerShown: false,
   keyboardHidesTabBar: true,
   tabBarActiveTintColor: colors.green,
@@ -21,7 +22,8 @@ const tabIcon = route => ({
     paddingBottom: Platform.OS === 'android' ? 8 : 8,
     ...textStyles.Bold,
     ...textStyles.Center,
-    ...textStyles.Small
+    ...textStyles.Small,
+    color: (drawerStatus === 'open' && route.name === "Profile") ? colors.green : colors.white
   },
   tabBarStyle: {
     position: 'absolute',
@@ -29,19 +31,27 @@ const tabIcon = route => ({
     backgroundColor: '#2c2c2c',
     borderColor: 'black',
     borderTopLeftRadius: 15,
-    borderTopRightRadius: 15
+    borderTopRightRadius: 15,
   },
-  tabBarIcon: ({ color, size }) => {
+  tabBarIcon: ({ color, size, focused}) => {
     let iconName
+
     const {t} = useTranslation()
     if (route.name === t('titleHome')) {
       iconName = 'home'
+      // make the home icon white when the profile drawer is open or it's not in focus
+      color = (drawerStatus == 'open' || !focused) ? colors.white : colors.green; 
     } else if (route.name === t('titleProfile')) {
       iconName = 'user'
+      // make the profile icon green when the profile drawer is open, otherwise white
+      color = drawerStatus === 'open' ? colors.green : colors.white;
     }
     else if (route.name === 'Language') {
       iconName = 'language'
+      // make the language icon white when the profile drawer is open or it's not in focus
+      color = (drawerStatus == 'open' || !focused) ? colors.white : colors.green;
     }
+
     return (
       <View style={{ paddingTop: scale(10), paddingHorizontal: scale(12) }}>
         <Icon type="font-awesome" color={color} name={iconName} size={30} />
@@ -49,6 +59,8 @@ const tabIcon = route => ({
     )
   }
 })
+
+
 const tabOptions = () => ({
   keyboardHidesTabBar: true,
   activeTintColor: colors.iconPink,


### PR DESCRIPTION
**Issue:** The profile button was not being highlighted when the menu/side drawer was being opened. This was because the profile "tab" was actually not a tab, but a drawer, thus the tab-specific functionalities (active color & inactive color) were not being applied. 

**Solution:** When exporting the Tab Icon, I implemented checks for the drawer status and the active state of other tabs, ensuring that only the active tab is highlighted in green, while the inactive tabs remain white.

Solution Result Video:


https://github.com/user-attachments/assets/5c1c3278-e54f-463e-9d89-b888e145cd14

