### PR TITLE
fix: Enatega Customer Application: No Visual Indication on Restaurant Details Card When Closed due to store timings

### DIFF
--- a/enatega-multivendor-app/src/components/Main/RestaurantCard/NewRestaurantCard.js
+++ b/enatega-multivendor-app/src/components/Main/RestaurantCard/NewRestaurantCard.js
@@ -35,7 +35,6 @@ const FAVOURITERESTAURANTS = gql`
 `
 
 function NewRestaurantCard(props) {
-
   const { t, i18n } = useTranslation()
   const configuration = useContext(ConfigurationContext)
   const navigation = useNavigation()
@@ -50,11 +49,9 @@ function NewRestaurantCard(props) {
     onCompleted,
     refetchQueries: [PROFILE, FAVOURITERESTAURANTS]
   })
-  // const isRestaurantOpen = props?.isOpen
   const isAvailable = props?.isAvailable
+  const isRestaurantClosed = !isAvailable
 
-  const isRestaurantClosed = !isAvailable;
-// console.log("isAvailable--->>",isAvailable)
   function onCompleted() {
     FlashMessage({ message: t('favouritelistUpdated') })
   }
@@ -114,10 +111,28 @@ function NewRestaurantCard(props) {
               props?.fullWidth && { width: '100%' }
             ]}
           />
+          {/* Resturant Availability Status Label */}
+          <View style={{
+            position: 'absolute',
+            top: 12,
+            left: 12,
+            backgroundColor: 'rgba(128, 128, 128, 0.9)',
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 4
+          }}>
+            <TextDefault
+              H5
+              bold
+              textColor={currentTheme.white}
+            >
+              {isRestaurantClosed ? t('Closed') : t('Open')}
+            </TextDefault>
+          </View>
           {isRestaurantClosed && (
             <View style={styles(currentTheme).closedOverlay}>
               <TextDefault H4 textColor={currentTheme.white} bold>
-                Closed
+                {t('Closed')}
               </TextDefault>
             </View>
           )}

--- a/enatega-multivendor-app/src/screens/Favourite/Favourite.js
+++ b/enatega-multivendor-app/src/screens/Favourite/Favourite.js
@@ -150,7 +150,7 @@ function Favourite() {
               isCategories
               fullWidth
               isOpen={true}
-              isAvailable={item.isAvailable ||  true}
+              isAvailable={item.isAvailable ||  false}
             />
           )
         }}

--- a/enatega-multivendor-app/src/screens/Profile/Profile.js
+++ b/enatega-multivendor-app/src/screens/Profile/Profile.js
@@ -250,7 +250,7 @@ function Profile(props) {
                             reviewCount={item.reviewCount}
                             isCategories
                             isOpen={true}
-                            isAvailable={item.isAvailable || true}
+                            isAvailable={item.isAvailable || false}
                             
                           />
                         )


### PR DESCRIPTION
Added a Status Label to the restaurant cards whom are open as per isAvailability prop from data of  apollo client and whom are closed to eliminate confusion for User experience and to clearly differentiate between closed & open restaurants in the app hence fixing the [/issues/1008]

**Screenshot of the fix added below:**

![Screenshot_20250220_162354_host exp exponent](https://github.com/user-attachments/assets/5d2db0bb-70eb-49e4-812e-72dd3fe0a9ca)
