### PR TITLE
fix: Filtered/Removed Default Add-ons from add-ons option in admin dashboard Fixed

### DIFF
--- a/enatega-multivendor-admin/lib/ui/screen-components/protected/restaurant/add-on/view/main/index.tsx
+++ b/enatega-multivendor-admin/lib/ui/screen-components/protected/restaurant/add-on/view/main/index.tsx
@@ -21,7 +21,6 @@ import CategoryTableHeader from '../header/table-header';
 
 // Utilities and Data
 import CustomDialog from '@/lib/ui/useable-components/delete-dialog';
-import { generateDummyAddons } from '@/lib/utils/dummy';
 
 // Context
 import { useQueryGQL } from '@/lib/hooks/useQueryQL';
@@ -137,8 +136,10 @@ export default function OptionMain({
           />
         }
         data={
-          data?.restaurant?.addons.slice().reverse() ||
-          (loading ? generateDummyAddons() : [])
+          (data?.restaurant?.addons || [])
+            .filter(addon => addon.title !== 'Default Addon') // Filtered out default addons from backend data
+            .slice()
+            .reverse() || []
         }
         filters={filters}
         setSelectedData={setSelectedProducts}


### PR DESCRIPTION
Filtered the default addon data coming from backend into the addons page table so that there should be no already created Default Add-ons showing hence fixing [/issues/998]

**Potential Backend Recommendation for permanent fix of this issue:**

1. Check your database/backend for where these default addons are being created for new restaurants.
2. Remove the the backend logic that creates default addons when a new restaurant is created.

**Screenshot of the fix added below:**

![issue](https://github.com/user-attachments/assets/50ca9bc5-213c-4c44-9f4d-5234928236ff)
