### PR TITLE
fix: Showing by default 2-options added in options adding feature in Admin Dashboard Fixed

### DIFF
--- a/enatega-multivendor-admin/lib/ui/screen-components/protected/restaurant/options/view/main/index.tsx
+++ b/enatega-multivendor-admin/lib/ui/screen-components/protected/restaurant/options/view/main/index.tsx
@@ -27,7 +27,6 @@ import {
 // GraphQL
 import { DELETE_OPTION, GET_OPTIONS_BY_RESTAURANT_ID } from '@/lib/api/graphql';
 import { RestaurantLayoutContext } from '@/lib/context/restaurant/layout-restaurant.context';
-import { generateDummyOptions } from '@/lib/utils/dummy';
 import { useMutation } from '@apollo/client';
 import CategoryTableHeader from '../header/table-header';
 import { useTranslations } from 'next-intl';
@@ -132,8 +131,10 @@ export default function OptionMain({
           />
         }
         data={
-          data?.restaurant?.options.slice().reverse() ||
-          (loading ? generateDummyOptions() : [])
+          (data?.restaurant?.options || [])
+            .filter(option => option.title !== '7up' && option.title !== 'Pepsi') // Filter out default options cpming from the backend
+            .slice()
+            .reverse()|| []
         }
         filters={filters}
         setSelectedData={setSelectedProducts}


### PR DESCRIPTION
Filtered/Remove the default options of 7up & Pepsi that were coming from backend data so that the options list should be empty by default, allowing the user to add options manually hence fixing [/issues/910]

**Potential Backend Recommendation for permanent fix of this issue:**

1. Check your database/backend for where these default options are being created for new stores.
2. Remove the the backend logic that creates default options when a new store is created.

**Screenshot of the fix added below:**

![image](https://github.com/user-attachments/assets/5c43ccf0-ce46-4aab-846f-d06af493f86d)
