### PR TITLE
fix: convert order ID to uppercase in order details

### DIFF
--- a/enatega-multivendor-web/src/components/Orders/OrderDetail/DetailCard.js
+++ b/enatega-multivendor-web/src/components/Orders/OrderDetail/DetailCard.js
@@ -74,7 +74,7 @@ function DetailCard(props) {
                   classes.smallText
                 )}`}
               >
-                {props.orderId ?? "..."}
+                {props.orderId ? props.orderId.toUpperCase() : "..."}
               </Typography>
             </Grid>
           </Grid>


### PR DESCRIPTION
Converted order id to uppercase 
Fixes https://github.com/enatega/food-delivery-multivendor/issues/1293#issue-3100006800