### PR TITLE
Fix: Added padding below "Add" button in Add Vendors page

### DIFF
--- a/enatega-multivendor-admin/lib/ui/screen-components/protected/super-admin/vendor/form/vendor-add-form/index.tsx
+++ b/enatega-multivendor-admin/lib/ui/screen-components/protected/super-admin/vendor/form/vendor-add-form/index.tsx
@@ -361,7 +361,7 @@ export default function VendorAddForm({
                           }}
                         />
 
-                        <div className="mt-4 flex justify-end">
+                        <div className="py-4 flex justify-end">
                           <CustomButton
                             className="h-10 w-fit border-gray-300 bg-black px-8 text-white"
                             label={isEditingVendor ? t('Update') : t('Add')}


### PR DESCRIPTION
Added padding below "Add" button in Add Vendors page

issue: https://github.com/enatega/food-delivery-multivendor/issues/1271