### PR TITLE
Fix : "Total Stores Earnings” Displaying Negative in Admin Panel

### DIFF
--- a/enatega-multivendor-admin/lib/ui/screen-components/protected/super-admin/earnings/view/header/screen-header/index.tsx
+++ b/enatega-multivendor-admin/lib/ui/screen-components/protected/super-admin/earnings/view/header/screen-header/index.tsx
@@ -30,7 +30,7 @@ const EarningsSuperAdminHeader = ({
         />
         <StatsCard
           label={t('Total Stores Earning')}
-          total={formatNumber(earnings?.storeTotal || 0)}
+          total = {formatNumber((earnings?.storeTotal || 0) * -1)}
           icon={faDollarSign}
           isClickable={false}
           route="" // loading={loading}


### PR DESCRIPTION
Fixed #1319 