### PR TITLE
#1350 fix

### DIFF
--- a/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
+++ b/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
@@ -67,9 +67,33 @@ export const NOTIFICATIONS_TABLE_COLUMNS = () => {
         headerName: t('Date'),
         propertyName: 'createdAt',
         body: (rowData: INotification) => {
-          const seconds = parseInt(rowData.createdAt);
-          const newDate = new Date(seconds).toDateString();
-          return <span>{newDate}</span>;
+          let dateObj;
+          if (!rowData.createdAt) {
+            return <span>Invalid Date</span>;
+          }
+          // Try to parse as number (timestamp)
+          const timestamp = Number(rowData.createdAt);
+          if (!isNaN(timestamp)) {
+            // If it's in seconds, convert to ms
+            dateObj = new Date(timestamp > 1e12 ? timestamp : timestamp * 1000);
+          } else {
+            // Fallback to ISO string
+            dateObj = new Date(rowData.createdAt);
+          }
+          const isValid = !isNaN(dateObj.getTime());
+          return (
+            <span>
+              {isValid
+                ? dateObj.toLocaleString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })
+                : 'Invalid Date'}
+            </span>
+          );
         },
       },
       {


### PR DESCRIPTION

This issue #1350 was caused by improper handling of the `createdAt` field in the notification data:

- The code attempted to parse `createdAt` using `parseInt` and passed the result directly to the JavaScript `Date` constructor.
- If `createdAt` was an ISO string (e.g., `"2024-06-01T12:34:56.789Z"`), `parseInt` would return `NaN`, resulting in an invalid date.
- If `createdAt` was a timestamp in seconds, it was not converted to milliseconds, which is required by the `Date` constructor.
- As a result, all dates appeared as “Invalid Date,” preventing admins from tracking when notifications were sent or received.

### Solution

This PR updates the date formatting logic in the notifications table to robustly handle both ISO strings and numeric timestamps:

- The code now checks if `createdAt` is present.
- It attempts to parse `createdAt` as a number:
  - If it’s a valid number, it checks if it’s in milliseconds or seconds (by comparing to `1e12`) and converts to milliseconds if necessary.
  - If it’s not a valid number, it falls back to parsing it as an ISO date string.
- The code then checks if the resulting date is valid.
- If valid, it displays the date in a user-friendly format (e.g., “25 June 2025, 10:45 AM”).
- If invalid, it displays “Invalid Date” as a fallback.

### Impact

- The Date column in the Notification tab now correctly displays properly formatted timestamps for all notifications.

---

