### PR TITLE
fix: Enatega Rider App: The total price on the order detail within the proces...

### DIFF
--- a/enatega-multivendor-rider/lib/ui/screen-components/home/orders/main/item-details/index.tsx
+++ b/enatega-multivendor-rider/lib/ui/screen-components/home/orders/main/item-details/index.tsx
@@ -5,6 +5,23 @@ import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Image, Text, View } from "react-native";
 
+type IOrderItem = IOrder["items"][number];
+
+const getAddonsPrice = (item: IOrderItem) =>
+  item?.addons?.reduce(
+    (addonsTotal, addon) =>
+      addonsTotal +
+      (addon?.options?.reduce(
+        (optionsTotal, option) => optionsTotal + (option?.price ?? 0),
+        0,
+      ) ?? 0),
+    0,
+  ) ?? 0;
+
+const getItemTotal = (item: IOrderItem) =>
+  ((item?.variation?.price ?? 0) + getAddonsPrice(item)) *
+  (item?.quantity ?? 0);
+
 const ItemDetails = ({
   orderData: order,
 }: {
@@ -20,7 +37,7 @@ const ItemDetails = ({
 
   const itemAmount = useMemo(() => {
     return order?.items?.reduce((sum, item) => {
-      return sum + item.quantity * item.variation.price;
+      return sum + getItemTotal(item);
     }, 0);
   }, [order?.items]);
 
@@ -127,7 +144,7 @@ const ItemDetails = ({
                   style={{ color: appTheme.fontMainColor }}
                 >
                   {configuration?.currencySymbol}
-                  {item.variation?.price}
+                  {getItemTotal(item).toFixed(2)}
                 </Text>
               </View>
             </View>
@@ -155,7 +172,7 @@ const ItemDetails = ({
             style={{ color: appTheme.fontMainColor }}
           >
             {configuration?.currencySymbol}
-            {itemAmount}
+            {(itemAmount ?? 0).toFixed(2)}
           </Text>
         </View>
       </View>


### PR DESCRIPTION
Fixes #1960

## Root cause

Rider order-detail item pricing ignores addon prices and quantity

## Changes

- Compute each item's line total as quantity x (variation price + sum of addon option prices) with safe fallbacks, use it for both the per-item PRICE column and the "Total" row, and format both as 2-decimal currency values so the item list is arithmetically consistent and matches the customer app's addon-inclusive pricing.