### PR TITLE
fix: Enatega Web: Show cancellation reason for both restaurant and customer o...

### DIFF
--- a/enatega-multivendor-web/lib/api/graphql/queries/order-tracking/index.ts
+++ b/enatega-multivendor-web/lib/api/graphql/queries/order-tracking/index.ts
@@ -81,6 +81,7 @@ export const ORDER_TRACKING = gql`query OrderDetails($orderDetailsId: String!) {
     createdAt
     completionTime
     cancelledAt
+    reason
     assignedAt
     deliveredAt
     acceptedAt

--- a/enatega-multivendor-web/lib/api/graphql/subscription/orders/index.ts
+++ b/enatega-multivendor-web/lib/api/graphql/subscription/orders/index.ts
@@ -86,6 +86,7 @@ export const SUBSCRIPTION_ORDER = gql`
       }
       completionTime
       preparationTime
+      reason
     }
   }
 `;

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancel-order-success-modal.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancel-order-success-modal.tsx
@@ -7,11 +7,13 @@ import React from "react";
 interface CancelOrderSuccessModalProps {
   visible: boolean;
   onHide: () => void;
+  reason?: string;
 }
 //  const theme = useTheme();
 function CancelOrderSuccessModal({
   visible,
   onHide,
+  reason,
 }: CancelOrderSuccessModalProps) {
   // const router = useRouter();
   // create a function when user onHide then it will redirect to discover screen
@@ -68,6 +70,11 @@ function CancelOrderSuccessModal({
         <h2 className="text-xl font-semibold mb-2 dark:text-gray-100">
           {t("your_order_is_cancelled")}
         </h2>
+        {reason?.trim() && (
+          <p className="text-gray-700 text-sm text-center mb-2 dark:text-gray-300">
+            {reason}
+          </p>
+        )}
         <p className="text-gray-600 text-sm text-center dark:text-gray-400">
           {t("delete_success")}
         </p>

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancel-order-success-modal.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancel-order-success-modal.tsx
@@ -31,6 +31,7 @@ function CancelOrderSuccessModal({
   // }, [visible]);
 
   const t = useTranslations();
+  const trimmedReason = reason?.trim();
   return (
     <Dialog
       contentClassName="p-6 dark:bg-gray-800 dark:text-gray-300 p-6"
@@ -70,9 +71,9 @@ function CancelOrderSuccessModal({
         <h2 className="text-xl font-semibold mb-2 dark:text-gray-100">
           {t("your_order_is_cancelled")}
         </h2>
-        {reason?.trim() && (
+        {trimmedReason && (
           <p className="text-gray-700 text-sm text-center mb-2 dark:text-gray-300">
-            {reason}
+            {trimmedReason}
           </p>
         )}
         <p className="text-gray-600 text-sm text-center dark:text-gray-400">

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancelOrderModal.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/cancelOrderModal.tsx
@@ -11,7 +11,7 @@ interface CancelOrderModalProps {
   visible: boolean;
   onHide: () => void;
   orderId: string;
-  onSuccess: () => void;
+  onSuccess: (reason?: string) => void;
 }
 
 function CancelOrderModal({
@@ -33,7 +33,7 @@ function CancelOrderModal({
         message: t("order_cancelled_success_message"),
       });
       console.log("onSuccess is called");
-      onSuccess();
+      onSuccess(data?.abortOrder?.reason);
       // Refresh the order tracking page to show the updated status
     },
     onError: (error) => {

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
@@ -17,6 +17,9 @@ function TrackingOrderDetails({
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
   const [setshowCancelOrderSuccessModal, setSetshowCancelOrderSuccessModal] =
     useState(orderTrackingDetails?.orderStatus === "CANCELLED" ? true : false);
+  const [cancellationReason, setCancellationReason] = useState<
+    string | undefined
+  >(undefined);
   const { CURRENCY_SYMBOL } = useConfig();
   // Format currency values
   const formatCurrency = (amount: number) => {
@@ -294,8 +297,9 @@ function TrackingOrderDetails({
         onHide={() => {
           setIsCancelModalVisible(false);
         }}
-        onSuccess={() => {
+        onSuccess={(reason) => {
           setIsCancelModalVisible(false);
+          setCancellationReason(reason);
           setSetshowCancelOrderSuccessModal(true);
         }}
         orderId={orderTrackingDetails._id}
@@ -303,7 +307,7 @@ function TrackingOrderDetails({
       <CancelOrderSuccessModal
         visible={setshowCancelOrderSuccessModal}
         onHide={() => setSetshowCancelOrderSuccessModal(false)}
-        reason={orderTrackingDetails.reason}
+        reason={cancellationReason ?? orderTrackingDetails.reason}
       />
     </div>
   );

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
@@ -307,7 +307,7 @@ function TrackingOrderDetails({
       <CancelOrderSuccessModal
         visible={setshowCancelOrderSuccessModal}
         onHide={() => setSetshowCancelOrderSuccessModal(false)}
-        reason={cancellationReason ?? orderTrackingDetails.reason}
+        reason={cancellationReason?.trim() || orderTrackingDetails.reason}
       />
     </div>
   );

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-order-details.tsx
@@ -303,6 +303,7 @@ function TrackingOrderDetails({
       <CancelOrderSuccessModal
         visible={setshowCancelOrderSuccessModal}
         onHide={() => setSetshowCancelOrderSuccessModal(false)}
+        reason={orderTrackingDetails.reason}
       />
     </div>
   );

--- a/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-status-card.tsx
+++ b/enatega-multivendor-web/lib/ui/screen-components/protected/order-tracking/components/tracking-status-card.tsx
@@ -186,7 +186,10 @@ function TrackingStatusCard({ orderTrackingDetails }: TrackingStatusCardProps) {
         return t("Completed");
       }
       case "CANCELLED": {
-        return orderTrackingDetails.reason || t("Cancelled");
+        const cancellationReason = orderTrackingDetails.reason?.trim();
+        return cancellationReason
+          ? `${t("Cancelled")} ${cancellationReason}`
+          : t("Cancelled");
       }
       default:
         return t("Processing");

--- a/enatega-multivendor-web/lib/ui/screens/protected/order/tracking/index.tsx
+++ b/enatega-multivendor-web/lib/ui/screens/protected/order/tracking/index.tsx
@@ -100,9 +100,9 @@ export default function OrderTrackingScreen({
         completionTime:
           subscriptionData.completionTime ||
           orderTrackingDetails.completionTime,
+        reason: subscriptionData.reason || orderTrackingDetails.reason,
       }
       : orderTrackingDetails;
-
   if (mergedOrderDetails?.orderStatus === "PICKUP") {
     mergedOrderDetails = {
       ...mergedOrderDetails,


### PR DESCRIPTION
Fixes #1656

## Root cause

Web order query never selects Order.reason

## Changes

- Added the `reason` field to the web app's ORDER_TRACKING query and SUBSCRIPTION_ORDER subscription, merged it into the tracking screen's live order state, and surfaced it in the tracking status card message and the cancellation modal. The rendering code already expected `orderTrackingDetails.reason` but the field was never requested, so it was always undefined. Restaurant-side visibility of a customer's reason is not changed: the customer `abortOrder(id)` mutation has no reason argument in the proprietary API and the restaurant UI lives in enatega-multivendor-store, outside this issue's "Enatega Web App" scope. No checks were run: no Node/npm toolchain is available in this environment, and the repo has no unit-test framework for the web app (only Cypress e2e needing a live API), so no regression test was practical.