### PR TITLE
fix: Enatega Admin Dashboard: Notification date displays incorrect random num...

### DIFF
--- a/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
+++ b/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
@@ -13,6 +13,27 @@ import { GET_NOTIFICATIONS, SEND_NOTIFICATION_USER } from '@/lib/api/graphql';
 import { ToastContext } from '@/lib/context/global/toast.context';
 import { useTranslations } from 'next-intl';
 
+const formatNotificationDate = (createdAt: string) => {
+  if (!createdAt) return '—';
+
+  const timestamp = Number(createdAt);
+  const date = new Date(Number.isNaN(timestamp) ? createdAt : timestamp);
+
+  if (Number.isNaN(date.getTime())) return '—';
+
+  const formattedDate = date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+  const formattedTime = date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return `${formattedDate}, ${formattedTime}`;
+};
+
 export const NOTIFICATIONS_TABLE_COLUMNS = () => {
   // Hooks
   const t = useTranslations();
@@ -67,7 +88,7 @@ export const NOTIFICATIONS_TABLE_COLUMNS = () => {
         headerName: t('Date'),
         propertyName: 'createdAt',
         body: (rowData: INotification) => {
-          return <span>{rowData.createdAt}</span>;
+          return <span>{formatNotificationDate(rowData.createdAt)}</span>;
         },
       },
       {

--- a/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
+++ b/enatega-multivendor-admin/lib/ui/useable-components/table/columns/notification-columns.tsx
@@ -13,11 +13,18 @@ import { GET_NOTIFICATIONS, SEND_NOTIFICATION_USER } from '@/lib/api/graphql';
 import { ToastContext } from '@/lib/context/global/toast.context';
 import { useTranslations } from 'next-intl';
 
-const formatNotificationDate = (createdAt: string) => {
-  if (!createdAt) return '—';
+const formatNotificationDate = (
+  createdAt: string | number | null | undefined
+) => {
+  if (createdAt === null || createdAt === undefined) return '—';
 
-  const timestamp = Number(createdAt);
-  const date = new Date(Number.isNaN(timestamp) ? createdAt : timestamp);
+  const value = typeof createdAt === 'string' ? createdAt.trim() : createdAt;
+  if (value === '') return '—';
+
+  const timestamp = typeof value === 'number' ? value : Number(value);
+  const date = new Date(
+    typeof value === 'number' || !Number.isNaN(timestamp) ? timestamp : value
+  );
 
   if (Number.isNaN(date.getTime())) return '—';
 


### PR DESCRIPTION
Fixes #1994

## Root cause

Raw epoch timestamp rendered as notification Date column

## Changes

- Format the notification `createdAt` value before rendering in the Date column, converting epoch-millisecond strings (and ISO strings) into a localized `dd Mon yyyy, HH:mm` display with a placeholder for missing/invalid values, matching the existing date formatting pattern used in user-columns.tsx.